### PR TITLE
Add nice error page and feedback button

### DIFF
--- a/now.json
+++ b/now.json
@@ -3,5 +3,8 @@
       "env": {
         "VUE_APP_CSVAPI_URL": "@vue_app_csvapi_url"
       }
+    },
+    "github": {
+      "silent": true
     }
   }

--- a/src/views/TableView.vue
+++ b/src/views/TableView.vue
@@ -3,7 +3,7 @@
         <b-form v-if="!csvUrl" class="m-4">
             <b-input
                 class="mb-2 mt-2"
-                placeholder="URL du CSV à convertir en API"
+                placeholder="URL du fichier à visualiser (CSV ou XLS)"
                 v-model="csvUrlFieldValue"
             ></b-input>
             <b-button variant="primary" @click="redirect">Lancer la conversion 🚀</b-button>

--- a/src/views/TableView.vue
+++ b/src/views/TableView.vue
@@ -3,12 +3,34 @@
         <b-form v-if="!csvUrl" class="m-4">
             <b-input
                 class="mb-2 mt-2"
-                placeholder="URL of the CSV to apify"
+                placeholder="URL du CSV à convertir en API"
                 v-model="csvUrlFieldValue"
             ></b-input>
-            <b-button variant="primary" @click="redirect">Go 🚀</b-button>
+            <b-button variant="primary" @click="redirect">Lancer la conversion 🚀</b-button>
         </b-form>
-        <b-alert variant="danger" :show="hasError">{{ error }}</b-alert>
+        <div v-if="hasError" class="m-4">
+            <b-card
+                header-bg-variant="danger"
+                border-variant="danger"
+                header="🤕 Nous n'avons pas pu convertir ce fichier"
+                header-border-variant="danger"
+                header-text-variant="white"
+                align="center"
+            >
+                <b-card-text>
+                    <dl>
+                        <dt>Détails de l'erreur</dt>
+                        <dd>
+                            {{ error.error }}
+                            <span v-if="error.details"> {{ error.details }}</span>
+                        </dd>
+                        <dt v-if="error.id">Identifiant de l'erreur</dt>
+                        <dd v-if="error.id">{{ error.id }}</dd>
+                    </dl>
+                    <b-button @click="openIssue" variant="outline-danger" size="lg">Signaler cette erreur sur Github</b-button>
+                </b-card-text>
+            </b-card>
+        </div>
         <b-table v-if="rows.length" hover small :items="rows" :fields="fields" :no-local-sorting="true" @sort-changed="sort"></b-table>
         <b-pagination v-if="rows.length" align="center" size="lg" :total-rows="totalRows" v-model="page" :per-page="pageSize" @input="changePage"></b-pagination>
     </div>
@@ -59,9 +81,10 @@ export default {
         showError(res) {
             console.error(res)
             this.hasError = true
-            this.error = `Error: ${res.body.error}`
-            if (res.body.details) {
-                this.error += `(${res.body.details})`
+            this.error = {
+                error: res.body.error,
+                details: res.body.details,
+                id: res.body.error_id,
             }
             this.loader.hide()
         },
@@ -118,6 +141,16 @@ export default {
         redirect() {
             const csvUrl = this.csvUrlFieldValue
             document.location = `${document.location.protocol}//${document.location.host}/?url=${csvUrl}`
+        },
+        openIssue() {
+            const title = `Impossible de convertir le fichier`
+            const body = `
+Impossible de convertir le fichier situé ici : ${this.csvUrl}%0A%0A
+${this.error.error} ${this.error.details || ''}%0A%0A
+Identifiant : ${this.error.id || ''}
+`
+            const githubLink = `https://github.com/etalab/csvapi/issues/new?labels=live-feedback&title=${title}&body=${body}`
+            window.open(githubLink, '_blank')
         }
     },
     watch: {


### PR DESCRIPTION
<img width="1148" alt="Capture d'écran 2019-12-27 15 01 53" src="https://user-images.githubusercontent.com/119625/71519952-f7392680-28b9-11ea-97ab-0570b93bc268.png">

Le bouton renvoie vers [une nouvelle issue sur github]( https://github.com/etalab/csvapi/issues/new?labels=live-feedback&title=Impossible%20de%20convertir%20le%20fichier&body=Impossible%20de%20convertir%20le%20fichier%20situé%20ici%20:%20https://gist.githubusercontent.com/abulte/cce925b4e361b3916082c03f880c11c3/raw/0dde9af950dc0a3906a7b545695db995e46cfba9/bad.csv%0A%0AError%20parsing%20CSV:%20Row%200%20has%203%20values,%20but%20Table%20only%20has%202%20columns.%20%0A%0AIdentifiant%20:%20bba78c80bdde4c8f863044ab4a229568).