### PR TITLE
More specific css rule to override grey background color

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -635,7 +635,7 @@ html {
   height: 100%;
 }
 
-thead {
+.fr-table thead {
   background-color: white;
   background-image: none;
 }


### PR DESCRIPTION
The grey background only showed up in dev when using `npm run serve`