### PR TITLE
Add matomo tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ Known environment variables are:
 
 - `VUE_APP_CSVAPI_URL`: csvapi instance URL
 - `VUE_APP_FILTERS_ENABLED`: boolean, enables or disables filter support
+
+If you want to enable matomo tracking, you should specify the target site id:
+- `VUE_APP_MATOMO_SITE_ID`

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,8 @@ function _meta(name) {
 export const csvapiUrl = process.env.VUE_APP_CSVAPI_URL || _meta('csvapi-url')
 export const pageSize = _meta('page-size') || 10
 export const dataGouvUrl = "https://www.data.gouv.fr/fr/"
+export const matomoUrl = "https://stats.data.gouv.fr/"
+export const matomoSiteId = process.env.VUE_APP_MATOMO_SITE_ID
 
 /**
  * @param {string} id

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import "@gouvfr/dsfr/dist/dsfr/dsfr.module"
 
 import App from './App.vue'
 import store from './store'
+import matomo from './matomo'
 
 Vue.use(VueResource)
 

--- a/src/matomo.js
+++ b/src/matomo.js
@@ -1,8 +1,7 @@
 import {matomoUrl, matomoSiteId} from '@/config'
 
-console.log(matomoSiteId)
 if (matomoSiteId) {
-  var _paq = _paq || [];
+  var _paq = window._paq = window._paq || [];
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
 
@@ -13,10 +12,8 @@ if (matomoSiteId) {
     var d=document,
       g=d.createElement('script'),
       s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript';
-    g.defer=true;
     g.async=true;
-    g.src=u+'piwik.js';
+    g.src=u+'matomo.js';
     s.parentNode.insertBefore(g,s);
   })();
 }

--- a/src/matomo.js
+++ b/src/matomo.js
@@ -1,0 +1,22 @@
+import {matomoUrl, matomoSiteId} from '@/config'
+
+console.log(matomoSiteId)
+if (matomoSiteId) {
+  var _paq = _paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+
+  (function() {
+    var u=matomoUrl;
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', matomoSiteId]);
+    var d=document,
+      g=d.createElement('script'),
+      s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript';
+    g.defer=true;
+    g.async=true;
+    g.src=u+'piwik.js';
+    s.parentNode.insertBefore(g,s);
+  })();
+}


### PR DESCRIPTION
Fix https://github.com/etalab/data.gouv.fr/issues/945

Deactivated by default, matomo tracking can be activated by setting the correct matomo site id using `VUE_APP_MATOMO_SITE_ID`.
No site has been created yet on stats.data.gouv.fr/ instance.
Default tracking is used, differentiating between page views based on `?url` param.