### PR TITLE
smaller padding + no overflow header/footer

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fr-table">
-    <table ref="table">
-      <thead>
+    <table ref="table" @scroll="testScroll($event)">
+      <thead :style="{ left: '-' + scrollTab + 'px' }">
         <tr>
           <th 
             scope="col"
@@ -249,6 +249,7 @@ export default {
         region: {},
         url: {}
       },
+      scrollTab:0
     }
   },
   computed: {
@@ -617,6 +618,9 @@ export default {
     },
     exportData(){
       return this.dataEndpoint + '/export' + document.location.search
+    },
+    testScroll(event){
+      this.scrollTab = event.target.scrollLeft
     }
   },
   created () {
@@ -647,6 +651,13 @@ html {
 .fr-table thead {
   background-color: white;
   background-image: none;
+  position: fixed;
+  z-index: 999;
+
+}
+
+.fr-table tbody {
+  top:116px;
 }
 
 tfoot {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -635,13 +635,15 @@ export default {
 <style scoped>
 html {
     height: 100%;
+    overflow: hidden;
 }
 
 .fr-table {
-  overflow: auto;
+  overflow: scroll;
   height: 100vh;
-  padding-bottom: 4rem;
+  padding-bottom: 385px;
   margin-bottom: 0;
+  
 }
 
 .fr-table table {
@@ -741,6 +743,10 @@ th, td {
 
   .fr-table td{
     padding:0.75rem;
+  }
+
+  .fr-table {
+    padding-bottom: 169px;
   }
 
 }

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="fr-table">
-    <table ref="table" @scroll="testScroll($event)">
+  <div class="fr-table" >
+    <table ref="table" @scroll="handleScroll($event)">
       <thead :style="{ left: '-' + scrollTab + 'px' }">
         <tr>
           <th 
@@ -53,7 +53,7 @@
           </th>
         </tr>
       </thead>
-      <tbody>
+      <tbody id="body">
         <tr
           v-for="(row, index) in rows" 
           :key="row[0]"
@@ -249,7 +249,8 @@ export default {
         region: {},
         url: {}
       },
-      scrollTab:0
+      scrollTab:0,
+      lastBiggerScroll:0
     }
   },
   computed: {
@@ -605,9 +606,18 @@ export default {
         return 'https://annuaire-entreprises.data.gouv.fr/etablissement/' + id;
       }
     },
-    handleScroll () {
-      let bottomOfWindow = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop) + window.innerHeight + 1 >= document.documentElement.offsetHeight
-      if (bottomOfWindow) {
+    handleScroll (event) {
+
+      var tableTop = event.target.getBoundingClientRect().top + 100
+
+      console.log(tableTop)
+
+      console.log("scroll",event.target.scrollTop+tableTop)
+      console.log("height",event.target.offsetHeight)
+      console.log("lastScroll",this.lastBiggerScroll)
+      
+      if(event.target.scrollTop+tableTop>event.target.offsetHeight&&event.target.scrollTop+tableTop>this.lastBiggerScroll){
+        this.lastBiggerScroll = event.target.scrollTop+tableTop+event.target.offsetHeight
         this.page = this.page + 1
         this.changePage()
       }
@@ -619,15 +629,12 @@ export default {
     exportData(){
       return this.dataEndpoint + '/export' + document.location.search
     },
-    testScroll(event){
-      this.scrollTab = event.target.scrollLeft
-    }
   },
   created () {
-    window.addEventListener('scroll', this.handleScroll);
+    
   },
   destroyed () {
-    window.removeEventListener('scroll', this.handleScroll);
+    
   }
 }
 </script>
@@ -651,13 +658,11 @@ html {
 .fr-table thead {
   background-color: white;
   background-image: none;
-  position: fixed;
-  z-index: 999;
 
 }
 
 .fr-table tbody {
-  top:116px;
+  height: auto;
 }
 
 tfoot {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fr-table" >
     <table ref="table" @scroll="handleScroll($event)">
-      <thead :style="{ left: '-' + scrollTab + 'px' }">
+      <thead id="tabhead" :style="{ left: '-' + scrollTab + 'px' }">
         <tr>
           <th 
             scope="col"
@@ -608,13 +608,7 @@ export default {
     },
     handleScroll (event) {
 
-      var tableTop = event.target.getBoundingClientRect().top + 100
-
-      console.log(tableTop)
-
-      console.log("scroll",event.target.scrollTop+tableTop)
-      console.log("height",event.target.offsetHeight)
-      console.log("lastScroll",this.lastBiggerScroll)
+      var tableTop = event.target.getBoundingClientRect().top + document.getElementById("tabhead").offsetHeight
       
       if(event.target.scrollTop+tableTop>event.target.offsetHeight&&event.target.scrollTop+tableTop>this.lastBiggerScroll){
         this.lastBiggerScroll = event.target.scrollTop+tableTop+event.target.offsetHeight
@@ -658,8 +652,11 @@ html {
 .fr-table thead {
   background-color: white;
   background-image: none;
-
+  position: sticky;
+  top:0;
+  z-index: 999;
 }
+
 
 .fr-table tbody {
   height: auto;

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fr-table" >
     <table ref="table" @scroll="handleScroll($event)">
-      <thead id="tabhead" :style="{ left: '-' + scrollTab + 'px' }">
+      <thead id="tabhead">
         <tr>
           <th 
             scope="col"
@@ -249,7 +249,6 @@ export default {
         region: {},
         url: {}
       },
-      scrollTab:0,
       lastBiggerScroll:0
     }
   },

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -656,6 +656,7 @@ tfoot {
   color: var(--text-inverted-grey);
   width: 100%;
   z-index: 6;
+  overflow: hidden;
 }
 
 tfoot .fr-btn--secondary {
@@ -722,6 +723,14 @@ th, td {
 
 .messageNoResults{
   min-height: 400px;
+}
+
+@media (min-width: 48em){
+
+  .fr-table td{
+    padding:0.75rem;
+  }
+
 }
 
 </style>

--- a/src/views/HeaderApp.vue
+++ b/src/views/HeaderApp.vue
@@ -39,12 +39,13 @@ export default {
 .headerapp{
     padding-left: 15px;
     padding-right: 15px;
-    padding-top: 3px;
-    padding-bottom: 3px;
+    padding-top: 10px;
+    padding-bottom: 10px;
     background-color: #E6EEFE;
     justify-content: space-between;
     width: 100%;
     border-bottom: 2px solid #E6EEFE;
+    overflow: hidden;
 }
 
 .fr-enlarge-link{

--- a/src/views/InfosDgv.vue
+++ b/src/views/InfosDgv.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <h2 v-if="display" class="fr-pl-2w fr-py-2w fr-m-0 infosdgv">
+      Jeux de données
       <a 
         :href="getDataGouvUrl('datasets/'+dgvInfos.dataset_id)"
         class="text-label-blue-cumulus"

--- a/src/views/TableView.vue
+++ b/src/views/TableView.vue
@@ -130,7 +130,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
   html {
     overflow: hidden;
   }

--- a/src/views/TableView.vue
+++ b/src/views/TableView.vue
@@ -129,3 +129,9 @@ export default {
   }
 }
 </script>
+
+<style>
+  html {
+    overflow: hidden;
+  }
+</style>

--- a/src/views/TableView.vue
+++ b/src/views/TableView.vue
@@ -122,6 +122,7 @@ export default {
   },
   watch: {
     csvUrl (value) {
+      if(value){ document.querySelectorAll('body')[0].style.overflow = 'hidden' }
       if (!value) return
       this.$store.dispatch('apify', this.csvUrl).finally(() => {
       })
@@ -129,9 +130,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-  html {
-    overflow: hidden;
-  }
-</style>


### PR DESCRIPTION
@agarrone j'ai pris en compte tes retours sur le nouveau header/les cells du tableau
Le header et le footer du tableau n'ont plus de scroll mais pas sûr que ça corrige à 100% les soucis de double barres de scroll (ils peuvent venir d'autres choses)

![Capture d’écran 2023-01-16 à 15 43 38](https://user-images.githubusercontent.com/21242433/212705365-763dd8ed-b292-42fe-a42d-3f363853872b.png)
